### PR TITLE
Do not disable [Status]-Button on cancelled report

### DIFF
--- a/lua/damagelogs/cl_tabs/rdm_manager.lua
+++ b/lua/damagelogs/cl_tabs/rdm_manager.lua
@@ -465,7 +465,7 @@ function Damagelog:DrawRDMManager(x,y)
 		SetState:SetPos(510, 4)
 		SetState:SetSize(125, 18)
 		SetState.Think = function(self)
-			self:SetDisabled(not Damagelog.SelectedReport or Damagelog.SelectedReport.status == RDM_MANAGER_CANCELED)
+			self:SetDisabled(not Damagelog.SelectedReport)
 		end
 		SetState.DoClick = function()
 			local menu = DermaMenu()


### PR DESCRIPTION
With the status button disabled, the admins can't hide cancelled reports or write their own conclusions down.

Cancelled reports may still document something against the server rules - and admins can't see, if another admin has already taken care of this