### PR TITLE
Another new logtype (credits)

### DIFF
--- a/lua/damagelogs/damagelog_events/bodyfound.lua
+++ b/lua/damagelogs/damagelog_events/bodyfound.lua
@@ -1,7 +1,7 @@
 if SERVER then
 	Damagelog:EventHook("TTTBodyFound")
 else
-	Damagelog:AddFilter("Show Found Bodies", DAMAGELOG_FILTER_BOOL, true)
+	Damagelog:AddFilter("Show found bodies", DAMAGELOG_FILTER_BOOL, true)
 	Damagelog:AddColor("Found Body", Color(127,0,255))
 end
 
@@ -25,7 +25,7 @@ function event:ToString(v)
 end
 
 function event:IsAllowed(tbl)
-	return Damagelog.filter_settings["Show Found Bodies"]
+	return Damagelog.filter_settings["Show found bodies"]
 end
 
 function event:Highlight(line, tbl, text)

--- a/lua/damagelogs/damagelog_events/credits.lua
+++ b/lua/damagelogs/damagelog_events/credits.lua
@@ -1,0 +1,54 @@
+if SERVER then
+	hook.Add("Initialize", "Damagelog_ORAddCredits", function()
+		local plymeta = FindMetaTable( "Player" )
+		if not plymeta then Error("FAILED TO FIND PLAYER TABLE") return end
+		function plymeta:AddCredits(amt)
+		   self:SetCredits(self:GetCredits() + amt)
+		   hook.Call("TTTAddCredits", GAMEMODE, self, amt)
+		end
+	end)
+
+	Damagelog:EventHook("TTTAddCredits")
+else
+	Damagelog:AddFilter("Show credit changes", DAMAGELOG_FILTER_BOOL, false)
+	Damagelog:AddColor("Credits", Color(255,155,0))
+end
+
+local event = {}
+
+event.Type = "CRED"
+
+function event:TTTAddCredits(ply, credits)
+	self.CallEvent({
+		[1] = (IsValid(ply) and ply:Nick() or "<Disconnected Player>"),
+		[2] = (IsValid(ply) and ply:GetRole() or "disconnected"),
+		[3] = (IsValid(ply) and ply:SteamID() or "<Disconnected Player>"),
+		[4] = credits
+	})
+end
+
+function event:ToString(v)
+	return string.format("%s [%s] %s %s credit%s.", v[1], Damagelog:StrRole(v[2]), v[4]>0 and "got" or "lost", v[4]>0 and v[4] or -v[4], v[4] > 1 and "s" or "")
+end
+
+function event:IsAllowed(tbl)
+	return Damagelog.filter_settings["Show credit changes"]
+end
+
+function event:Highlight(line, tbl, text)
+	if table.HasValue(Damagelog.Highlighted, tbl[1]) or table.HasValue(Damagelog.Highlighted, tbl[4]) then
+		return true
+	end
+	return false
+end
+
+function event:GetColor(tbl)
+	return Damagelog:GetColor("Credits")
+end
+
+function event:RightClick(line, tbl, text)
+	line:ShowTooLong(true)
+	line:ShowCopy(true, { tbl[1], tbl[3] })
+end
+
+Damagelog:AddEvent(event)

--- a/lua/damagelogs/damagelog_events/ttt_radio.lua
+++ b/lua/damagelogs/damagelog_events/ttt_radio.lua
@@ -1,7 +1,7 @@
 if SERVER then
 	Damagelog:EventHook("TTTPlayerRadioCommand")
 else
-	Damagelog:AddFilter("Show Radio commands", DAMAGELOG_FILTER_BOOL, false)
+	Damagelog:AddFilter("Show radio commands", DAMAGELOG_FILTER_BOOL, false)
 	Damagelog:AddColor("Radio Command Default", Color(182,182,182))
 	Damagelog:AddColor("Radio Command TeamKOS", Color(255,0,0))
 end
@@ -76,7 +76,7 @@ function event:ToString(v)
 end
 
 function event:IsAllowed(tbl)
-	return Damagelog.filter_settings["Show Radio commands"]
+	return Damagelog.filter_settings["Show radio commands"]
 end
 
 function event:Highlight(line, tbl, text)

--- a/lua/damagelogs/damagelog_events/ttt_radio.lua
+++ b/lua/damagelogs/damagelog_events/ttt_radio.lua
@@ -1,7 +1,7 @@
 if SERVER then
 	Damagelog:EventHook("TTTPlayerRadioCommand")
 else
-	Damagelog:AddFilter("Show Radio commands", DAMAGELOG_FILTER_BOOL, true)
+	Damagelog:AddFilter("Show Radio commands", DAMAGELOG_FILTER_BOOL, false)
 	Damagelog:AddColor("Radio Command Default", Color(182,182,182))
 	Damagelog:AddColor("Radio Command TeamKOS", Color(255,0,0))
 end


### PR DESCRIPTION
The credit logtype is pretty spammy, so it is disabled by default.
Some events could need consolidation (detective gains on traitor death), some may be skipped (item purchase).

Also changed the filternames of the other two logs to lowercase and disabled the radio filter by default.