### PR TITLE
Death scene - fixed corpse text color

### DIFF
--- a/lua/damagelogs/cl_recording.lua
+++ b/lua/damagelogs/cl_recording.lua
@@ -1,4 +1,4 @@
- 
+
 local mdl = Model("models/player/arctic.mdl")
 
 CreateClientConVar("ttt_death_scene_slowmo", "0", FCVAR_ARCHIVE)
@@ -237,12 +237,12 @@ hook.Add("HUDPaint", "Scene_Record", function()
 			if model.corpse then
 				local pos = model.pos:ToScreen()
 				if IsOffScreen(pos) then continue end
-				if not found then
+				if model.found then
 					surface.SetTextColor(Color(255, 200, 15))
 				else
-					surface.SetTextColor(color_white)
+					surface.SetTextColor(Color(255, 0, 0))
 				end
-				local text = nick.."'s corpse"
+				local text = nick.."'s corpse "..(model.found and "(ID)" or "(UnID)")
 				local w,h = surface.GetTextSize(text)
 				surface.SetTextPos(pos.x - w/2, pos.y)
 				surface.DrawText(text)
@@ -388,6 +388,7 @@ hook.Add("Think", "Think_Record", function()
 			if v.corpse then
 				models[k].pos = v.pos
 				models[k].ang = v.ang
+				models[k].found = v.found
 			else
 				local vector = v.pos
 				local angle = v.ang


### PR DESCRIPTION
I recolored the texts. Unidentified bodies' text is now red. It should probably be some other color like light blue, to make them easier to spot among the players (low health = red text), and the greyscale of death scenes. I also added whether the bodies have been found or not in text: "(ID)" vs "(UnID)", because most players won't understand what the difference in color means