### PR TITLE
use tonumber() when comparing

### DIFF
--- a/lua/damagelogs/ulx/sv_autoslay.lua
+++ b/lua/damagelogs/ulx/sv_autoslay.lua
@@ -219,7 +219,7 @@ hook.Add("TTTBeginRound", "Damagelog_AutoSlay", function()
 end)
 
 hook.Add("PlayerDisconnected", "Autoslay_Message", function(ply)
-	if tonumber(ply.AutoslaysLeft) and ply.AutoslaysLeft > 0 then
+	if tonumber(ply.AutoslaysLeft) and tonumber(ply.AutoslaysLeft) > 0 then
 		net.Start("DL_PlayerLeft")
 		net.WriteString(ply:Nick())
 		net.WriteString(ply:SteamID())


### PR DESCRIPTION
tonumber() wont change the variable, only the result is a number.
On our server, this comparision failed afaik every time. Maybe it's the fault of my custom code, but this change at least won't break anything and it seems like you intended to use tonumber() yourself.