### PR TITLE
Add gender neutral pronoun to the chat report message

### DIFF
--- a/lua/damagelogs/cl_rdm_manager.lua
+++ b/lua/damagelogs/cl_rdm_manager.lua
@@ -344,6 +344,6 @@ net.Receive("DL_Answering_global", function(_len)
 	local nick = net.ReadString()
 	local ply = LocalPlayer()
 	if not ply:IsActive() then
-		chat.AddText(Color(255,62,62), nick, color_white, " is answering to his reports.")
+		chat.AddText(Color(255,62,62), nick, color_white, " is answering to their reports.")
 	end
 end)


### PR DESCRIPTION
Another accepted pull request got most of the male oriented pronouns, but this one was missed, so I've corrected it now.