### PR TITLE
Stop SQL Error "no such column: steamid"

### DIFF
--- a/lua/damagelogs/ulx/sv_autoslay.lua
+++ b/lua/damagelogs/ulx/sv_autoslay.lua
@@ -35,7 +35,7 @@ hook.Add("PlayerAuthed", "DamagelogNames", function(ply, steamid, uniqueid)
 	elseif query != name then
 		sql.Query("UPDATE damagelog_names SET name = "..sql.SQLStr(name).." WHERE steamid = '"..steamid.."' LIMIT 1;")
 	end
-	local c = sql.Query("SELECT slays FROM damagelog_autoslay WHERE steamid = '"..steamid.."' LIMIT 1;")
+	local c = sql.Query("SELECT slays FROM damagelog_autoslay WHERE ply = '"..steamid.."' LIMIT 1;")
 	if not tonumber(c) then c = 0 end
 	ply.AutoslaysLeft = c
 	net.Start("DL_AutoslaysLeft")


### PR DESCRIPTION
Code I use to test for SQL errors:
```lua
local sqlQuery = sql.Query
local errs = {}
function _G.sql.Query( str )
	local ret = sqlQuery( str )
	local err = sql.LastError()
	if err and not errs[err] then
		local err = sql.LastError()
		MsgC(Color(241, 196, 15), "Error on SQL Query: " .. str .. "\n")
		MsgC(Color(241, 196, 15), "Error message: " .. err .. "\n")
		debug.Trace()
		errs[err] = true
	end
	return ret
end
```