### PR TITLE
Added and moddified options in "Take action"-menu, added options to allow more reports

### DIFF
--- a/lua/damagelogs/client/rdm_manager.lua
+++ b/lua/damagelogs/client/rdm_manager.lua
@@ -37,8 +37,10 @@ local function BuildReportFrame(report)
 				break
 			end
 		end
-
-		if not found then return end
+		
+		
+			if not found then return end
+		
 		net.Start("DL_Answering")
 		net.SendToServer()
 		ReportFrame = vgui.Create("DFrame")
@@ -86,7 +88,7 @@ local function BuildReportFrame(report)
 			PanelList:AddItem(TextEntry)
 			local Button = vgui.Create("DButton")
 			Button:SetText(TTTLogTranslate(GetDMGLogLang, "Send"))
-
+			
 			Button.DoClick = function()
 				local text = string.Trim(TextEntry:GetValue())
 				local size = #text
@@ -231,7 +233,7 @@ end
 
 vgui.Register("Damagelog_Player", PANEL, "DPanel")
 
-function Damagelog:ReportWindow(deathLogs, previousReports, currentReports, dnas)
+function Damagelog:ReportWindow(found, deathLogs, previousReports, currentReports, dnas)
 
 	local isAdmin = LocalPlayer():CanUseRDMManager()
 
@@ -390,7 +392,11 @@ function Damagelog:ReportWindow(deathLogs, previousReports, currentReports, dnas
 			Submit:SetText(TTTLogTranslate(GetDMGLogLang, "NotEnoughCharacters"))
 		else
 			Submit:SetEnabled(true)
-			Submit:SetText(TTTLogTranslate(GetDMGLogLang, "Submit"))
+			if found then
+				Submit:SetText(TTTLogTranslate(GetDMGLogLang, "Submit"))
+			elseif not found then
+				Submit:SetText(TTTLogTranslate(GetDMGLogLang, "SubmitEvenWithNoStaff"))
+			end
 		end
 	end
 
@@ -712,7 +718,7 @@ net.Receive("DL_SendOwnReportInfo", function()
 end)
 
 net.Receive("DL_AllowReport", function()
-
+	local found = net.ReadBool()
 	local got_deathLogs = net.ReadUInt(1) == 1
 	local deathLogs = got_deathLogs and net.ReadTable() or false
 	local previousReports = net.ReadTable()
@@ -725,7 +731,7 @@ net.Receive("DL_AllowReport", function()
 		dnas[ply] = net.ReadUInt(1) == 1
 	end
 
-	Damagelog:ReportWindow(deathLogs, previousReports, currentReports, dnas)
+	Damagelog:ReportWindow(found,deathLogs, previousReports, currentReports, dnas)
 end)
 
 net.Receive("DL_SendReport", function()

--- a/lua/damagelogs/client/tabs/rdm_manager.lua
+++ b/lua/damagelogs/client/tabs/rdm_manager.lua
@@ -188,7 +188,15 @@ local function TakeAction()
 	if serverguard or ulx then
 	
 		if serverguard or (ulx and (mode == 1 or mode == 2)) then
-
+			local function SetConclusion(ply, num, reason)
+				net.Start("DL_Conclusion")
+				net.WriteUInt(1, 1)
+				net.WriteUInt(report.previous and 1 or 0, 1)
+				net.WriteUInt(report.index, 16)
+				net.WriteString("("..TTTLogTranslate(DMGLogLang, "Automatic")..") " .. ply .. (mode == 1 and " autoslain " or " autojailed ") .. num .. " times for " .. reason .. ".")
+				net.SendToServer()
+			end
+			
 			local slaynr_pnl = vgui.Create("DMenuOption", menuPanel)
 			local slaynr = DermaMenu(menuPanel)
 			slaynr:SetVisible(false)
@@ -200,84 +208,608 @@ local function TakeAction()
 			slaynr_pnl:SetText(txt)
 			slaynr_pnl:SetImage("icon16/lightning_go.png")
 			menuPanel:AddPanel(slaynr_pnl)
-
-			local function SetConclusion(ply, num, reason)
-				net.Start("DL_Conclusion")
-				net.WriteUInt(1, 1)
-				net.WriteUInt(report.previous and 1 or 0, 1)
-				net.WriteUInt(report.index, 16)
-				net.WriteString("("..TTTLogTranslate(DMGLogLang, "Automatic")..") " .. ply .. (mode == 1 and " autoslain " or " autojailed ") .. num .. " times for " .. reason .. ".")
-				net.SendToServer()
-			end
-
-			local function AddSlayPlayer(reported)
-				local ply_pnl = vgui.Create("DMenuOption", slaynr)
-				local ply = DermaMenu(ply_pnl)
-				ply:SetVisible(false)
-				ply_pnl:SetSubMenu(ply)
-				ply_pnl:SetText(reported and "Reported player" or "Victim")
-				ply_pnl:SetImage(reported and "icon16/user_delete.png" or "icon16/user.png")
-				slaynr:AddPanel(ply_pnl)
-
-				for k, v in ipairs({"bullet_green.png", "bullet_yellow.png", "bullet_red.png"}) do
-					local numbers_pnl = vgui.Create("DMenuOption", ply)
-					local numbers = DermaMenu(numbers_pnl)
-					numbers:SetVisible(false)
-					numbers_pnl:SetSubMenu(numbers)
-					numbers_pnl:SetText(k .. " times")
-					numbers_pnl:SetImage("icon16/" .. v)
-					ply:AddPanel(numbers_pnl)
-
-					numbers:AddOption("Default reason", function()
-						local ply = (reported and attacker) or (not reported and victim)
-
-						if IsValid(ply) then
-							if ulx then
-								RunConsoleCommand("ulx", mode == 1 and "aslay" or "ajail", ply:Nick(), tostring(k))
-							else
-								serverguard.command.Run("aslay", false, ply:Nick(), k, Damagelog.Autoslay_DefaultReason)
-							end
-							SetConclusion(ply:Nick(), k, "the default reason")
+			slaynr:AddOption("Reported player", function()
+				slaytyp = report.attacker_nick
+				slaytypiger = "atta"
+				RDMslay()
+			end):SetImage("icon16/user_delete.png")
+			slaynr:AddOption("Victim", function()
+				slaytyp = report.victim_nick
+				slaytypiger = "vict"
+				RDMslay()
+			end):SetImage("icon16/user.png")
+			function RDMslay()
+				local DermaPanel = vgui.Create( "DFrame" )
+				local weite = 500
+				local hoehe = 260
+				local abstand = 25
+				local groesse = 240
+				local rdm1 = Damagelog.Autoslay_DefaultReason1
+				local rdm2 = Damagelog.Autoslay_DefaultReason2
+				local rdm3 = Damagelog.Autoslay_DefaultReason3
+				local rdm4 = Damagelog.Autoslay_DefaultReason4
+				local rdm5 = Damagelog.Autoslay_DefaultReason5
+				local rdm6 = Damagelog.Autoslay_DefaultReason6
+				local rdm7 = Damagelog.Autoslay_DefaultReason7
+				local rdm8 = Damagelog.Autoslay_DefaultReason8
+				local rdm9 = Damagelog.Autoslay_DefaultReason9
+				local rdm10 = Damagelog.Autoslay_DefaultReason10
+				local rdm11 = Damagelog.Autoslay_DefaultReason11
+				local rdm12 = Damagelog.Autoslay_DefaultReason12
+				DermaPanel:SetPos( ScrW()/2-weite/2,ScrH()/2-hoehe/2 )
+				DermaPanel:SetSize( weite, hoehe )
+				if ulx and mode == 2 then
+					DermaPanel:SetTitle( "Jailing" )
+				else
+					DermaPanel:SetTitle( "Slaying" )
+				end
+				DermaPanel:SetVisible( true )
+				DermaPanel:SetDraggable( true )
+				DermaPanel:ShowCloseButton( true )
+				DermaPanel:MakePopup()
+				 
+				DermaList = vgui.Create( "DPanelList", DermaPanel )
+				DermaList:SetPos( abstand/2,abstand*1.5)
+				DermaList:SetSize( groesse, groesse/3 )
+				DermaList:SetSpacing( 5 )
+				DermaList:EnableHorizontal( false )
+				DermaList:EnableVerticalScrollbar( true )
+				
+				 
+					local one_slay = vgui.Create( "DCheckBoxLabel" )
+					one_slay:SetText( "1 slay" )
+					one_slay:SetValue( 1 )
+					one_slay:SizeToContents()
+				DermaList:AddItem( one_slay )
+				 
+					local two_slay = vgui.Create( "DCheckBoxLabel" )
+					two_slay:SetText( "2 slays" )
+					two_slay:SetValue( 0 )
+					two_slay:SizeToContents()
+				DermaList:AddItem( two_slay )
+				 
+					local three_slay = vgui.Create( "DCheckBoxLabel" )
+					three_slay:SetText( "3 slays" )
+					three_slay:SetValue( 0 )
+					three_slay:SizeToContents()
+				DermaList:AddItem( three_slay )
+				
+				anzahl = 1
+				
+				local DLabel = vgui.Create( "DLabel", DermaPanel )
+				DLabel:SetPos( abstand/2 + 5, groesse/2.5 + 65 )
+				DLabel:SetSize( abstand * 4.65 , 25 )
+				DLabel:SetText( "1" )
+				
+				function one_slay:OnChange( val1 )
+					if val1 then
+						two_slay:SetValue(0)
+						three_slay:SetValue(0)
+						anzahl = 1
+						DLabel:SetText( anzahl )
+					end
+				end
+				function two_slay:OnChange( val1 )
+					if val1 then
+						one_slay:SetValue(0)
+						three_slay:SetValue(0)
+						anzahl = 2
+						DLabel:SetText( anzahl )
+					end
+				end
+				function three_slay:OnChange( val1 )
+					if val1 then
+						two_slay:SetValue(0)
+						one_slay:SetValue(0)
+						anzahl = 3
+						DLabel:SetText( anzahl )
+					end
+				end
+				
+				DermaList = vgui.Create( "DPanelList", DermaPanel )
+				DermaList:SetPos( abstand/2 + groesse/2,abstand*1.5)
+				DermaList:SetSize( groesse, groesse/2 )
+				DermaList:SetSpacing( 5 )
+				DermaList:EnableHorizontal( false )
+				DermaList:EnableVerticalScrollbar( true )
+				 
+					local rdmr_1 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_1:SetText( rdm1 )
+					rdmr_1:SetValue( 0 )
+					rdmr_1:SizeToContents()
+				DermaList:AddItem( rdmr_1 )
+				
+				
+					local rdmr_2 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_2:SetText( rdm2 )
+					rdmr_2:SetValue( 0 )
+					rdmr_2:SizeToContents()
+				DermaList:AddItem( rdmr_2 )
+				 
+					local rdmr_3 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_3:SetText( rdm3 )
+					rdmr_3:SetValue( 0 )
+					rdmr_3:SizeToContents()
+				DermaList:AddItem( rdmr_3 )
+				 
+					local rdmr_4 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_4:SetText( rdm4 )
+					rdmr_4:SetValue( 0 )
+					rdmr_4:SizeToContents()
+				DermaList:AddItem( rdmr_4 )
+				 
+					local rdmr_5 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_5:SetText( rdm5 )
+					rdmr_5:SetValue( 0 )
+					rdmr_5:SizeToContents()
+				DermaList:AddItem( rdmr_5 )
+				
+					local rdmr_6 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_6:SetText( rdm6 )
+					rdmr_6:SetValue( 0 )
+					rdmr_6:SizeToContents()
+				DermaList:AddItem( rdmr_6 )
+				
+				DermaList = vgui.Create( "DPanelList", DermaPanel )
+				DermaList:SetPos( abstand + groesse * 1.25, abstand*1.5)
+				DermaList:SetSize( groesse, groesse/2 )
+				DermaList:SetSpacing( 5 )
+				DermaList:EnableHorizontal( false )
+				DermaList:EnableVerticalScrollbar( true )
+				 
+				 
+					local rdmr_7 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_7:SetText( rdm7 )
+					rdmr_7:SetValue( 0 )
+					rdmr_7:SizeToContents()
+				DermaList:AddItem( rdmr_7 )
+				 
+					local rdmr_8 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_8:SetText( rdm8 )
+					rdmr_8:SetValue( 0 )
+					rdmr_8:SizeToContents()
+				DermaList:AddItem( rdmr_8 )
+				 
+					local rdmr_9 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_9:SetText( rdm9 )
+					rdmr_9:SetValue( 0 )
+					rdmr_9:SizeToContents()
+				DermaList:AddItem( rdmr_9 )
+				 
+					local rdmr_10 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_10:SetText( rdm10 )
+					rdmr_10:SetValue( 0 )
+					rdmr_10:SizeToContents()
+				DermaList:AddItem( rdmr_10 )
+				
+					local rdmr_11 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_11:SetText( rdm11 )
+					rdmr_11:SetValue( 0 )
+					rdmr_11:SizeToContents()
+				DermaList:AddItem( rdmr_11 )
+				
+					local rdmr_12 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_12:SetText( rdm12 )
+					rdmr_12:SetValue( 0 )
+					rdmr_12:SizeToContents()
+				DermaList:AddItem( rdmr_12 )
+				
+				
+				reasonhauraus = true
+				local DermaACheckbox = vgui.Create( "DCheckBox", DermaPanel )
+				DermaACheckbox:SetPos( abstand/2 + groesse/2 ,groesse*2/3 + 5)
+				DermaACheckbox:SetValue( 1 )
+				function DermaACheckbox:OnChange( reasonjanein )
+					if reasonjanein then
+						reasonhauraus = true
+						reasonupdate()
+					else
+						reasonhauraus = false
+						reasonupdate()
+					end
+				end
+				
+				local Shape = vgui.Create( "DShape", DermaPanel )
+				Shape:SetType( "Rect" )
+				Shape:SetPos( abstand/2 + groesse/2 - 10 ,abstand*1.5 - 5)
+				Shape:SetColor( Color( 255, 255, 255, 255 ) )
+				Shape:SetSize( 1, groesse*2/3 )
+				
+				local Shape = vgui.Create( "DShape", DermaPanel )
+				Shape:SetType( "Rect" )
+				Shape:SetPos( abstand/2 - 5, groesse/2.5 + 5)
+				Shape:SetColor( Color( 255, 255, 255, 255 ) )
+				Shape:SetSize( abstand * 4.65 , 1 )
+				
+				local Shape = vgui.Create( "DShape", DermaPanel )
+				Shape:SetType( "Rect" )
+				Shape:SetPos( abstand/2 - 5, groesse*2/3 + 31 )
+				Shape:SetColor( Color( 255, 255, 255, 255 ) )
+				Shape:SetSize( weite*23/24 + 5, 1 )
+				
+				local DLabel = vgui.Create( "DLabel", DermaPanel )
+				DLabel:SetPos( abstand/2, groesse/2.5 + 5 )
+				DLabel:SetSize( abstand * 4.65 , 25 )
+				DLabel:SetText( "You are going to slay" )
+				
+				local DLabel = vgui.Create( "DLabel", DermaPanel )
+				DLabel:SetPos( abstand/2 + 5, groesse/2.5 + 25 )
+				DLabel:SetSize( abstand * 4.65 - 15, 25 )
+				DLabel:SetText( slaytyp )
+				
+				local DLabel = vgui.Create( "DLabel", DermaPanel )
+				DLabel:SetPos( abstand/2, groesse/2.5 + 45 )
+				DLabel:SetSize( abstand * 4.65 , 25 )
+				DLabel:SetText( "this often:" )
+				
+				local DLabelr = vgui.Create( "DLabel", DermaPanel )
+				DLabelr:SetPos( abstand/2,groesse*2/3 + 31)				
+				DLabelr:SetSize( weite - abstand/2, 30 )	
+				DLabelr:SetText( "Reason: " )
+				
+				res1 = false
+				res2 = false
+				res3 = false
+				res4 = false
+				res5 = false
+				res6 = false
+				res7 = false
+				res8 = false
+				res9 = false
+				res10 = false
+				res11 = false
+				res12 = false
+				
+				function rdmr_1:OnChange( rees1 )
+					if rees1 then
+						res1 = true
+					else
+						res1 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_2:OnChange( rees2 )
+					if rees2 then
+						res2 = true
+					else
+						res2 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_3:OnChange( rees3 )
+					if rees3 then
+						res3 = true
+					else
+						res3 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_4:OnChange( rees4 )
+					if rees4 then
+						res4 = true
+					else
+						res4 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_5:OnChange( rees5 )
+					if rees5 then
+						res5 = true
+					else
+						res5 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_6:OnChange( rees6 )
+					if rees6 then
+						res6 = true
+					else
+						res6 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_7:OnChange( rees7 )
+					if rees7 then
+						res7 = true
+					else
+						res7 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_8:OnChange( rees8 )
+					if rees8 then
+						res8 = true
+					else
+						res8 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_9:OnChange( rees9 )
+					if rees9 then
+						res9 = true
+					else
+						res9 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_10:OnChange( rees10 )
+					if rees10 then
+						res10 = true
+					else
+						res10 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_11:OnChange( rees11 )
+					if rees11 then
+						res11 = true
+					else
+						res11 = false
+					end
+					reasonupdate()
+				end
+				
+				function rdmr_12:OnChange( rees12 )
+					if rees12 then
+						res12 = true
+					else
+						res12 = false
+					end
+					reasonupdate()
+				end
+				
+				changed = false
+				
+				local TexwtEntry = vgui.Create( "DTextEntry", DermaPanel )
+				TexwtEntry:SetPos( abstand/2 + groesse/2 + 25 ,groesse*2/3)
+				TexwtEntry:SetSize( groesse*1.5 - 35, 25 )
+				TexwtEntry:SetText( "another reason" )
+				TexwtEntry.OnEnter = function( self )
+					postings()
+				end
+				textreason = ""
+				function TexwtEntry:OnChange()
+					changed = true
+					reasonupdate()
+				end
+				
+				function reasonupdate()
+					reason5 = "Reason: "
+					if res1 then
+						reason5 = "Reason: "..rdm1
+					end
+					if res2 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm2
 						else
-							if ulx then
-								RunConsoleCommand("ulx", mode == 1 and "aslayid" or "ajailid", (reported and report.attacker) or (not reported and report.victim), tostring(k))
-								SetConclusion((reported and report.attacker_nick) or (not reported and report.victim_nick), k, "the default reason")
+							reason5 = reason5.." + " ..rdm2
+						end
+					end 
+					if res3 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm3
+						else
+							reason5 = reason5.." + " ..rdm3
+						end
+					end 
+					if res4 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm4
+						else
+							reason5 = reason5.." + " ..rdm4
+						end
+					end 
+					if res5 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm5
+						else
+							reason5 = reason5.." + " ..rdm5
+						end
+					end 
+					if res6 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm6
+						else
+							reason5 = reason5.." + " ..rdm6
+						end
+					end 
+					if res7 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm7
+						else
+							reason5 = reason5.." + " ..rdm7
+						end
+					end 
+					if res8 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm8
+						else
+							reason5 = reason5.." + " ..rdm8
+						end
+					end 
+					if res9 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm9
+						else
+							reason5 = reason5.." + " ..rdm9
+						end
+					end 
+					if res10 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm10
+						else
+							reason5 = reason5.." + " ..rdm10
+						end
+					end 
+					if res11 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm11
+						else
+							reason5 = reason5.." + " ..rdm11
+						end
+					end 
+					if res12 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm12
+						else
+							reason5 = reason5.." + " ..rdm12
+						end
+					end 
+					if reasonhauraus then
+						if changed then
+							if reason5 == "Reason: " then
+								reason5 = "Reason: "..TexwtEntry:GetValue()
 							else
-								Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "VictimReportedDisconnected"), 2, "buttons/weapon_cant_buy.wav")
+								reason5 = reason5.." + " ..TexwtEntry:GetValue()
 							end
 						end
-					end):SetImage("icon16/mouse.png")
-
-					numbers:AddOption("Set reason...", function()
-						local nick = (reported and report.attacker_nick) or (not reported and report.victim_nick)
-
-						Derma_StringRequest("Reason", "Please type the reason why you want to ".. (mode == 1 and "autoslay " or "autojail ") .. nick, "", function(txt)
-							local ply = (reported and attacker) or (not reported and victim)
-
-							if IsValid(ply) then
-								if ulx then
-									RunConsoleCommand("ulx", mode == 1 and "aslay" or "ajail", ply:Nick(), tostring(k), txt)
-								else
-									serverguard.command.Run("aslay", false, ply:Nick(), k, txt)
-								end
-								SetConclusion(ply:Nick(), k, "\"" .. txt .. "\"")
+					end
+					DLabelr:SetText(reason5)
+					reason5 = "Reason: "
+				end
+				
+				function postings()
+					reason4 = " "
+					if res1 then
+						reason4 = rdm1
+					end
+					if res2 then
+						if reason4 == " " then
+							reason4 = rdm2
+						else
+							reason4 = reason4.." + " ..rdm2
+						end
+					end 
+					if res3 then
+						if reason4 == " " then
+							reason4 = rdm3
+						else
+							reason4 = reason4.." + " ..rdm3
+						end
+					end 
+					if res4 then
+						if reason4 == " " then
+							reason4 = rdm4
+						else
+							reason4 = reason4.." + " ..rdm4
+						end
+					end 
+					if res5 then
+						if reason4 == " " then
+							reason4 = rdm5
+						else
+							reason4 = reason4.." + " ..rdm5
+						end
+					end 
+					if res6 then
+						if reason4 == " " then
+							reason4 = rdm6
+						else
+							reason4 = reason4.." + " ..rdm6
+						end
+					end 
+					if res7 then
+						if reason4 == " " then
+							reason4 = rdm7
+						else
+							reason4 = reason4.." + " ..rdm7
+						end
+					end 
+					if res8 then
+						if reason4 == " " then
+							reason4 = rdm8
+						else
+							reason4 = reason4.." + " ..rdm8
+						end
+					end 
+					if res9 then
+						if reason4 == " " then
+							reason4 = rdm9
+						else
+							reason4 = reason4.." + " ..rdm9
+						end
+					end 
+					if res10 then
+						if reason4 == " " then
+							reason4 = rdm10
+						else
+							reason4 = reason4.." + " ..rdm10
+						end
+					end 
+					if res11 then
+						if reason4 == " " then
+							reason4 = rdm11
+						else
+							reason4 = reason4.." + " ..rdm11
+						end
+					end 
+					if res12 then
+						if reason4 == " " then
+							reason4 = rdm12
+						else
+							reason4 = reason4.." + " ..rdm12
+						end
+					end 
+					if reasonhauraus then
+						if changed then
+							if reason4 == " " then
+								reason4 = TexwtEntry:GetValue()
 							else
-								if ulx then
-									RunConsoleCommand("ulx", mode == 1 and "aslayid" or "ajailid", (reported and report.attacker) or (not reported and report.victim), tostring(k), txt)
-									SetConclusion((reported and report.attacker_nick) or (not reported and report.victim_nick), k, "\"" .. txt .. "\"")
-								else
-									Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "VictimReportedDisconnected"), 2, "buttons/weapon_cant_buy.wav")
-								end
+								reason4 = reason4.." + " ..TexwtEntry:GetValue()
 							end
-						end)
-					end):SetImage("icon16/page_edit.png")
+						end
+					end
+					if slaytypiger == "atta" then
+						local ply = attacker
+						local plyid = report.attacker
+					elseif slaytypiger == "vict" then
+						local ply = victim
+						local plyid = report.victim
+					end
+					if IsValid(ply) then
+						if ulx then
+							RunConsoleCommand("ulx", mode == 1 and "aslay" or "ajail", slaytyp, anzahl, reason4)
+						else
+							serverguard.command.Run("aslay", false, slaytyp, anzahl, reason4)
+						end
+						SetConclusion(slaytyp, anzahl, reason4)
+					else
+						if ulx then
+							RunConsoleCommand("ulx", mode == 1 and "aslayid" or "ajailid", plyid, anzahl, reason4)
+							SetConclusion(slaytyp, anzahl, reason4)
+						else
+							Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "VictimReportedDisconnected"), 2, "buttons/weapon_cant_buy.wav")
+						end
+					end
+					reason4 = " "
+					DermaPanel:Close()
+				end
+				
+				local DermaButton = vgui.Create( "DButton" )	
+				DermaButton:SetParent( DermaPanel )
+				if ulx and mode == 2 then
+					DermaButton:SetText( "ajail!" )	
+				else
+					DermaButton:SetText( "aslay!" )	
+				end							 
+				DermaButton:SetPos( abstand/4,groesse*2/3 + 60)				
+				DermaButton:SetSize( weite - abstand/2 , 30 )				 
+				DermaButton.DoClick = function()			 
+					postings()			
 				end
 			end
-
-			AddSlayPlayer(true)
-			AddSlayPlayer(false)
 		end
-
+		
 		menuPanel:AddOption("Slay the reported player now", function()
 			if IsValid(attacker) then
 				if ulx then
@@ -289,57 +821,714 @@ local function TakeAction()
 				Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "RDMNotValid"), 2, "buttons/weapon_cant_buy.wav")
 			end
 		end):SetImage("icon16/lightning.png")
-
+		
 		local slaynr_pnl = vgui.Create("DMenuOption", menuPanel)
-		local slaynr = DermaMenu(menuPanel)
-		slaynr:SetVisible(false)
-		slaynr_pnl:SetSubMenu(slaynr)
-		local txt = "Remove autoslays of" 
-		if ulx and mode == 1 then
-			txt = "Remove autojails of"
-		elseif serverguard then
-			txt = "Remove 1 autoslay from"
-		end
-		slaynr_pnl:SetText(txt)
-		slaynr_pnl:SetImage("icon16/cancel.png")
-		menuPanel:AddPanel(slaynr_pnl)
-
-		slaynr:AddOption("The reported player", function()
-			if IsValid(attacker) then
-				if ulx then
-					RunConsoleCommand("ulx", mode == 1 and "aslay" or "ajail", attacker:Nick(), "0")
-				else
-					serverguard.command.Run("raslay", false, attacker:Nick())
-				end
-			else
-				if ulx then
-					RunConsoleCommand("ulx", mode == 1 and "aslayid" or "ajailid", report.attacker, "0")
+			local slaynr = DermaMenu(menuPanel)
+			slaynr:SetVisible(false)
+			slaynr_pnl:SetSubMenu(slaynr)
+			slaynr_pnl:SetText("Send message to")
+			slaynr_pnl:SetImage("icon16/user_edit.png")
+			menuPanel:AddPanel(slaynr_pnl)
+			slaynr:AddOption("Reported player", function()
+				if IsValid(attacker) then
+					Derma_StringRequest("private message", "What would you like to say to "..attacker:Nick().."?", "", function(nachricht)
+						if ulx then
+							RunConsoleCommand("ulx", "psay", attacker:Nick(), Damagelog.PrivateMessagePrefix.." "..nachricht)
+						else
+							--[[add serverguard private message-command here
+							variables:
+							playername: attacker:Nick()
+							message: Damagelog.PrivateMessagePrefix.." "..nachricht
+							]]
+						end
+					end)
 				else
 					Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "VictimReportedDisconnected"), 2, "buttons/weapon_cant_buy.wav")
 				end
-			end
-		end):SetImage("icon16/user_delete.png")
-
-		slaynr:AddOption("The victim", function()
-			if IsValid(victim) then
-				if ulx then
-					RunConsoleCommand("ulx", mode == 1 and "aslay" or "ajail", victim:Nick(), "0")
-				else
-					serverguard.command.Run("raslay", false, victim:Nick())
-				end
-			else
-				if ulx then
-					RunConsoleCommand("ulx", mode == 1 and "aslayid" or "ajailid", report.victim, "0")
+			end):SetImage("icon16/user_delete.png")
+			slaynr:AddOption("Victim", function()
+				if IsValid(victim) then
+					Derma_StringRequest("private message", "What would you like to say to "..victim:Nick().."?", "", function(nachricht)
+						if ulx then
+							RunConsoleCommand("ulx", "psay", victim:Nick(), Damagelog.PrivateMessagePrefix.." "..nachricht)
+						else
+							--[[add serverguard private message-command here
+							variables:
+							playername: victim:Nick()
+							message: Damagelog.PrivateMessagePrefix.." "..nachricht
+							]]
+						end
+					end)
 				else
 					Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "VictimReportedDisconnected"), 2, "buttons/weapon_cant_buy.wav")
-				end					
+				end
+			end):SetImage("icon16/user.png")
+		
+		local slaynr_pnl = vgui.Create("DMenuOption", menuPanel)
+			local slaynr = DermaMenu(menuPanel)
+			slaynr:SetVisible(false)
+			slaynr_pnl:SetSubMenu(slaynr)
+			slaynr_pnl:SetText("Ban player")
+			slaynr_pnl:SetImage("icon16/bomb.png")
+			menuPanel:AddPanel(slaynr_pnl)
+			slaynr:AddOption("Reported player", function()
+				slaytyp2 = report.attacker_nick
+				slaytypiger2 = "atta"
+				baning()
+			end):SetImage("icon16/user_delete.png")
+			slaynr:AddOption("Victim", function()
+				slaytyp2 = report.victim_nick
+				slaytypiger2 = "vict"
+				baning()
+			end):SetImage("icon16/user.png")
+			local function SetConclusion2(ply, num, reason)
+				net.Start("DL_Conclusion")
+				net.WriteUInt(1,1)
+				net.WriteUInt(report.previous and 1 or 0, 1)
+				net.WriteUInt(report.index, 16)
+				net.WriteString("(Auto) "..ply.." banned "..num.." for "..reason..".")
+				net.SendToServer()
 			end
-		end):SetImage("icon16/user.png")
+			function baning()
+				local DermaPanel = vgui.Create( "DFrame" )
+				local weite = 500
+				local hoehe = 260
+				local abstand = 25
+				local groesse = 240
+				local rdm1 = Damagelog.Ban_DefaultReason1
+				local rdm2 = Damagelog.Ban_DefaultReason2
+				local rdm3 = Damagelog.Ban_DefaultReason3
+				local rdm4 = Damagelog.Ban_DefaultReason4
+				local rdm5 = Damagelog.Ban_DefaultReason5
+				local rdm6 = Damagelog.Ban_DefaultReason6
+				local rdm7 = Damagelog.Ban_DefaultReason7
+				local rdm8 = Damagelog.Ban_DefaultReason8
+				local rdm9 = Damagelog.Ban_DefaultReason9
+				local rdm10 = Damagelog.Ban_DefaultReason10
+				local rdm11 = Damagelog.Ban_DefaultReason11
+				local rdm12 = Damagelog.Ban_DefaultReason12
+				DermaPanel:SetPos( ScrW()/2-weite/2,ScrH()/2-hoehe/2 )
+				DermaPanel:SetSize( weite, hoehe )
+				DermaPanel:SetTitle( "ban" )
+				DermaPanel:SetVisible( true )
+				DermaPanel:SetDraggable( true )
+				DermaPanel:ShowCloseButton( true )
+				DermaPanel:MakePopup()
+				 
+				DermaList = vgui.Create( "DPanelList", DermaPanel )
+				DermaList:SetPos( abstand/2,abstand*1.5)
+				DermaList:SetSize( groesse/3+20, groesse/3 )
+				DermaList:SetSpacing( 5 )
+				DermaList:EnableHorizontal( false )
+				DermaList:EnableVerticalScrollbar( true )
+				
+				local laeng = vgui.Create( "DTextEntry", DermaPanel )
+				laeng:SetSize(40/3.5,20)
+				laeng:SetText( "0" )
+				DermaList:AddItem( laeng )
+				 
+					local one_slay = vgui.Create( "DCheckBoxLabel" )
+					one_slay:SetText( "hours" )
+					one_slay:SetValue( 1 )
+					one_slay:SizeToContents()
+				DermaList:AddItem( one_slay )
+				 
+					local two_slay = vgui.Create( "DCheckBoxLabel" )
+					two_slay:SetText( "days" )
+					two_slay:SetValue( 0 )
+					two_slay:SizeToContents()
+				DermaList:AddItem( two_slay )
+				 
+					local three_slay = vgui.Create( "DCheckBoxLabel" )
+					three_slay:SetText( "weeks" )
+					three_slay:SetValue( 0 )
+					three_slay:SizeToContents()
+				DermaList:AddItem( three_slay )
+				
+				anzahl = "h"
+				
+				
+				
+				function one_slay:OnChange( val1 )
+					if val1 then
+						two_slay:SetValue(0)
+						three_slay:SetValue(0)
+						anzahl = "h"
+					end
+				end
+				function two_slay:OnChange( val1 )
+					if val1 then
+						one_slay:SetValue(0)
+						three_slay:SetValue(0)
+						anzahl = "d"
+					end
+				end
+				function three_slay:OnChange( val1 )
+					if val1 then
+						two_slay:SetValue(0)
+						one_slay:SetValue(0)
+						anzahl = "w"
+					end
+				end
+				
+				DermaList = vgui.Create( "DPanelList", DermaPanel )
+				DermaList:SetPos( abstand/2 + groesse/2,abstand*1.5)
+				DermaList:SetSize( groesse, groesse/2 )
+				DermaList:SetSpacing( 5 )
+				DermaList:EnableHorizontal( false )
+				DermaList:EnableVerticalScrollbar( true )
+				 
+					local rdmr_1 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_1:SetText( rdm1 )
+					rdmr_1:SetValue( 0 )
+					rdmr_1:SizeToContents()
+				DermaList:AddItem( rdmr_1 )
+				
+				
+					local rdmr_2 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_2:SetText( rdm2 )
+					rdmr_2:SetValue( 0 )
+					rdmr_2:SizeToContents()
+				DermaList:AddItem( rdmr_2 )
+				 
+					local rdmr_3 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_3:SetText( rdm3 )
+					rdmr_3:SetValue( 0 )
+					rdmr_3:SizeToContents()
+				DermaList:AddItem( rdmr_3 )
+				 
+					local rdmr_4 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_4:SetText( rdm4 )
+					rdmr_4:SetValue( 0 )
+					rdmr_4:SizeToContents()
+				DermaList:AddItem( rdmr_4 )
+				 
+					local rdmr_5 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_5:SetText( rdm5 )
+					rdmr_5:SetValue( 0 )
+					rdmr_5:SizeToContents()
+				DermaList:AddItem( rdmr_5 )
+				
+					local rdmr_6 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_6:SetText( rdm6 )
+					rdmr_6:SetValue( 0 )
+					rdmr_6:SizeToContents()
+				DermaList:AddItem( rdmr_6 )
+				
+				DermaList = vgui.Create( "DPanelList", DermaPanel )
+				DermaList:SetPos( abstand + groesse * 1.25, abstand*1.5)
+				DermaList:SetSize( groesse, groesse/2 )
+				DermaList:SetSpacing( 5 )
+				DermaList:EnableHorizontal( false )
+				DermaList:EnableVerticalScrollbar( true )
+				 
+				 
+					local rdmr_7 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_7:SetText( rdm7 )
+					rdmr_7:SetValue( 0 )
+					rdmr_7:SizeToContents()
+				DermaList:AddItem( rdmr_7 )
+				 
+					local rdmr_8 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_8:SetText( rdm8 )
+					rdmr_8:SetValue( 0 )
+					rdmr_8:SizeToContents()
+				DermaList:AddItem( rdmr_8 )
+				 
+					local rdmr_9 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_9:SetText( rdm9 )
+					rdmr_9:SetValue( 0 )
+					rdmr_9:SizeToContents()
+				DermaList:AddItem( rdmr_9 )
+				 
+					local rdmr_10 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_10:SetText( rdm10 )
+					rdmr_10:SetValue( 0 )
+					rdmr_10:SizeToContents()
+				DermaList:AddItem( rdmr_10 )
+				
+					local rdmr_11 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_11:SetText( rdm11 )
+					rdmr_11:SetValue( 0 )
+					rdmr_11:SizeToContents()
+				DermaList:AddItem( rdmr_11 )
+				
+					local rdmr_12 = vgui.Create( "DCheckBoxLabel" )
+					rdmr_12:SetText( rdm12 )
+					rdmr_12:SetValue( 0 )
+					rdmr_12:SizeToContents()
+				DermaList:AddItem( rdmr_12 )
+				
+				
+				reasonhauraus = true
+				local DermaACheckbox = vgui.Create( "DCheckBox", DermaPanel )
+				DermaACheckbox:SetPos( abstand/2 + groesse/2 ,groesse*2/3 + 5)
+				DermaACheckbox:SetValue( 1 )
+				function DermaACheckbox:OnChange( reasonjanein )
+					if reasonjanein then
+						reasonhauraus = true
+						reasonupdate2()
+					else
+						reasonhauraus = false
+						reasonupdate2()
+					end
+				end
+
+				local Shape = vgui.Create( "DShape", DermaPanel )
+				Shape:SetType( "Rect" )
+				Shape:SetPos( abstand/2 + groesse/2 - 10 ,abstand*1.5 - 5)
+				Shape:SetColor( Color( 255, 255, 255, 255 ) )
+				Shape:SetSize( 1, groesse*2/3 )
+				
+				local Shape = vgui.Create( "DShape", DermaPanel )
+				Shape:SetType( "Rect" )
+				Shape:SetPos( abstand/2 - 5, groesse/2.5 + 40)
+				Shape:SetColor( Color( 255, 255, 255, 255 ) )
+				Shape:SetSize( abstand * 4.65 , 1 )
+				
+				local Shape = vgui.Create( "DShape", DermaPanel )
+				Shape:SetType( "Rect" )
+				Shape:SetPos( abstand/2 - 5, groesse*2/3 + 31 )
+				Shape:SetColor( Color( 255, 255, 255, 255 ) )
+				Shape:SetSize( weite*23/24 + 5, 1 )
+				
+				local DLabel = vgui.Create( "DLabel", DermaPanel )
+				DLabel:SetPos( abstand/2, groesse/2.5 + 45 )
+				DLabel:SetSize( abstand * 4.65 , 25 )
+				DLabel:SetText( "You're going to ban" )
+				
+				local DLabel = vgui.Create( "DLabel", DermaPanel )
+				DLabel:SetPos( abstand/2 + 5, groesse/2.5 + 65 )
+				DLabel:SetSize( abstand * 4.65 - 15, 25 )
+				DLabel:SetText( slaytyp2 )
+				
+				local DLabelr = vgui.Create( "DLabel", DermaPanel )
+				DLabelr:SetPos( abstand/2,groesse*2/3 + 31)				
+				DLabelr:SetSize( weite - abstand/2, 30 )	
+				DLabelr:SetText( "Reason: " )
+				
+				res1 = false
+				res2 = false
+				res3 = false
+				res4 = false
+				res5 = false
+				res6 = false
+				res7 = false
+				res8 = false
+				res9 = false
+				res10 = false
+				res11 = false
+				res12 = false
+				
+				function rdmr_1:OnChange( rees1 )
+					if rees1 then
+						res1 = true
+					else
+						res1 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_2:OnChange( rees2 )
+					if rees2 then
+						res2 = true
+					else
+						res2 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_3:OnChange( rees3 )
+					if rees3 then
+						res3 = true
+					else
+						res3 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_4:OnChange( rees4 )
+					if rees4 then
+						res4 = true
+					else
+						res4 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_5:OnChange( rees5 )
+					if rees5 then
+						res5 = true
+					else
+						res5 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_6:OnChange( rees6 )
+					if rees6 then
+						res6 = true
+					else
+						res6 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_7:OnChange( rees7 )
+					if rees7 then
+						res7 = true
+					else
+						res7 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_8:OnChange( rees8 )
+					if rees8 then
+						res8 = true
+					else
+						res8 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_9:OnChange( rees9 )
+					if rees9 then
+						res9 = true
+					else
+						res9 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_10:OnChange( rees10 )
+					if rees10 then
+						res10 = true
+					else
+						res10 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_11:OnChange( rees11 )
+					if rees11 then
+						res11 = true
+					else
+						res11 = false
+					end
+					reasonupdate2()
+				end
+				
+				function rdmr_12:OnChange( rees12 )
+					if rees12 then
+						res12 = true
+					else
+						res12 = false
+					end
+					reasonupdate2()
+				end
+				
+				changed = false
+				
+				local TexwtEntry = vgui.Create( "DTextEntry", DermaPanel )
+				TexwtEntry:SetPos( abstand/2 + groesse/2 + 25,groesse*2/3)
+				TexwtEntry:SetSize( groesse*1.5 - 35, 25 )
+				TexwtEntry:SetText( "another reason" )
+				TexwtEntry.OnEnter = function( self )
+					postings2()
+				end
+				textreason = ""
+				function TexwtEntry:OnChange()
+					changed = true
+					reasonupdate2()
+				end
+				
+				function reasonupdate2()
+					reason5 = "Reason: "
+					if res1 then
+						reason5 = "Reason: "..rdm1
+					end
+					if res2 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm2
+						else
+							reason5 = reason5.." + " ..rdm2
+						end
+					end 
+					if res3 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm3
+						else
+							reason5 = reason5.." + " ..rdm3
+						end
+					end 
+					if res4 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm4
+						else
+							reason5 = reason5.." + " ..rdm4
+						end
+					end 
+					if res5 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm5
+						else
+							reason5 = reason5.." + " ..rdm5
+						end
+					end 
+					if res6 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm6
+						else
+							reason5 = reason5.." + " ..rdm6
+						end
+					end 
+					if res7 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm7
+						else
+							reason5 = reason5.." + " ..rdm7
+						end
+					end 
+					if res8 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm8
+						else
+							reason5 = reason5.." + " ..rdm8
+						end
+					end 
+					if res9 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm9
+						else
+							reason5 = reason5.." + " ..rdm9
+						end
+					end 
+					if res10 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm10
+						else
+							reason5 = reason5.." + " ..rdm10
+						end
+					end 
+					if res11 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm11
+						else
+							reason5 = reason5.." + " ..rdm11
+						end
+					end 
+					if res12 then
+						if reason5 == "Reason: " then
+							reason5 = "Reason: "..rdm12
+						else
+							reason5 = reason5.." + " ..rdm12
+						end
+					end 
+					if reasonhauraus then
+						if changed then
+							if reason5 == "Reason: " then
+								reason5 = "Reason: "..TexwtEntry:GetValue()
+							else
+								reason5 = reason5.." + " ..TexwtEntry:GetValue()
+							end
+						end
+					end
+					DLabelr:SetText(reason5)
+					reason5 = "Reason: "
+				end
+				
+				function postings2()
+					reason4 = " "
+					if res1 then
+						reason4 = rdm1
+					end
+					if res2 then
+						if reason4 == " " then
+							reason4 = rdm2
+						else
+							reason4 = reason4.." + " ..rdm2
+						end
+					end 
+					if res3 then
+						if reason4 == " " then
+							reason4 = rdm3
+						else
+							reason4 = reason4.." + " ..rdm3
+						end
+					end 
+					if res4 then
+						if reason4 == " " then
+							reason4 = rdm4
+						else
+							reason4 = reason4.." + " ..rdm4
+						end
+					end 
+					if res5 then
+						if reason4 == " " then
+							reason4 = rdm5
+						else
+							reason4 = reason4.." + " ..rdm5
+						end
+					end 
+					if res6 then
+						if reason4 == " " then
+							reason4 = rdm6
+						else
+							reason4 = reason4.." + " ..rdm6
+						end
+					end 
+					if res7 then
+						if reason4 == " " then
+							reason4 = rdm7
+						else
+							reason4 = reason4.." + " ..rdm7
+						end
+					end 
+					if res8 then
+						if reason4 == " " then
+							reason4 = rdm8
+						else
+							reason4 = reason4.." + " ..rdm8
+						end
+					end 
+					if res9 then
+						if reason4 == " " then
+							reason4 = rdm9
+						else
+							reason4 = reason4.." + " ..rdm9
+						end
+					end 
+					if res10 then
+						if reason4 == " " then
+							reason4 = rdm10
+						else
+							reason4 = reason4.." + " ..rdm10
+						end
+					end 
+					if res11 then
+						if reason4 == " " then
+							reason4 = rdm11
+						else
+							reason4 = reason4.." + " ..rdm11
+						end
+					end 
+					if res12 then
+						if reason4 == " " then
+							reason4 = rdm12
+						else
+							reason4 = reason4.." + " ..rdm12
+						end
+					end 
+					if reasonhauraus then
+						if changed then
+							if reason4 == " " then
+								reason4 = TexwtEntry:GetValue()
+							else
+								reason4 = reason4.." + " ..TexwtEntry:GetValue()
+							end
+						end
+					end
+					
+					if slaytypiger2 == "atta" then
+						play = attacker
+						play2 = report.attacker
+					elseif slaytypiger2 == "vict" then
+						play = victim
+						play2 = report.victim
+					end
+					
+					if IsValid(play) then
+						if ulx then
+							LocalPlayer():ConCommand('ulx ban "'..slaytyp2..'" '..laeng:GetValue()..''..anzahl..' '..reason4)
+						else
+							--[[add serverguard ban-command here
+							variables:
+							playername: slaytyp2
+							reason: reason4
+							lenght: laeng:GetValue()..''..anzahl
+							]]
+						end
+					else
+						if ulx then
+							LocalPlayer():ConCommand("ulx banid "..play2.." "..laeng:GetValue()..""..anzahl.." "..reason4)
+						else
+							--[[add serverguard banid-command here
+							variables:
+							steamid: play2
+							reason: reason4
+							lenght: laeng:GetValue()..''..anzahl
+							]]
+						end
+					end
+					if tostring(laeng:GetValue()) == "0" then
+						SetConclusion2(slaytyp2, "permanently", reason4)
+					else
+						SetConclusion2(slaytyp2, "for "..laeng:GetValue()..""..anzahl, reason4)
+					end
+					reason4 = " "
+					DermaPanel:Close()
+				end
+				
+				local DermaButton = vgui.Create( "DButton" )	
+				DermaButton:SetParent( DermaPanel )			 
+				DermaButton:SetText( "Ban!" )				 
+				DermaButton:SetPos( abstand/4,groesse*2/3 + 60)				
+				DermaButton:SetSize( weite - abstand/2 , 30 )				 
+				DermaButton.DoClick = function()			 
+					postings2()			
+				end
+			end
+			
+			local slaynr_pnl = vgui.Create("DMenuOption", menuPanel)
+			local slaynr = DermaMenu(menuPanel)
+			slaynr:SetVisible(false)
+			slaynr_pnl:SetSubMenu(slaynr)
+			local txt = "Remove autoslays of" 
+			if ulx and mode == 2 then
+				txt = "Remove autojails of"
+			elseif serverguard then
+				txt = "Remove 1 autoslay from"
+			end
+			slaynr_pnl:SetText(txt)
+			slaynr_pnl:SetImage("icon16/cancel.png")
+			menuPanel:AddPanel(slaynr_pnl)
+
+			slaynr:AddOption("The reported player", function()
+				if IsValid(attacker) then
+					if ulx then
+						RunConsoleCommand("ulx", mode == 1 and "aslay" or "ajail", attacker:Nick(), "0")
+					else
+						serverguard.command.Run("raslay", false, attacker:Nick())
+					end
+				else
+					if ulx then
+						RunConsoleCommand("ulx", mode == 1 and "aslayid" or "ajailid", report.attacker, "0")
+					else
+						Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "VictimReportedDisconnected"), 2, "buttons/weapon_cant_buy.wav")
+					end
+				end
+			end):SetImage("icon16/user_delete.png")
+
+			slaynr:AddOption("The victim", function()
+				if IsValid(victim) then
+					if ulx then
+						RunConsoleCommand("ulx", mode == 1 and "aslay" or "ajail", victim:Nick(), "0")
+					else
+						serverguard.command.Run("raslay", false, victim:Nick())
+					end
+				else
+					if ulx then
+						RunConsoleCommand("ulx", mode == 1 and "aslayid" or "ajailid", report.victim, "0")
+					else
+						Damagelog:Notify(DAMAGELOG_NOTIFY_ALERT, TTTLogTranslate(GetDMGLogLang, "VictimReportedDisconnected"), 2, "buttons/weapon_cant_buy.wav")
+					end					
+				end
+			end):SetImage("icon16/user.png")
 	end
-
+	
 	menuPanel:Open()
 end
-
 local PANEL = {}
 
 function PANEL:Init()
@@ -371,7 +1560,6 @@ function PANEL:SetReportsTable(tbl)
 	self.ReportsTable = tbl
 end
 
--- here comes autojail, too.
 function PANEL:GetStatus(report)
 	local str = status[report.status]
 

--- a/lua/damagelogs/config/config.lua
+++ b/lua/damagelogs/config/config.lua
@@ -64,9 +64,35 @@ Damagelog.ULX_AutoslayMode = 1
 
 Damagelog.ULX_Autoslay_ForceRole = true
 
--- Default autoslay reason (ULX and ServerGuard)
+-- Default autoslay reasons (ULX and ServerGuard)
 
-Damagelog.Autoslay_DefaultReason = "No reason specified"
+Damagelog.Autoslay_DefaultReason1 = "random kill"
+Damagelog.Autoslay_DefaultReason2 = "multiple random kills"
+Damagelog.Autoslay_DefaultReason3 = "random damage"
+Damagelog.Autoslay_DefaultReason4 = "multiple random damage"
+Damagelog.Autoslay_DefaultReason5 = "teamkill"
+Damagelog.Autoslay_DefaultReason6 = "needless report"
+Damagelog.Autoslay_DefaultReason7 = "unfitting answer"
+Damagelog.Autoslay_DefaultReason8 = "unfitting language"
+Damagelog.Autoslay_DefaultReason9 = "lying"
+Damagelog.Autoslay_DefaultReason10 = "propkill"
+Damagelog.Autoslay_DefaultReason11 = "teaming"
+Damagelog.Autoslay_DefaultReason12 = "random kos"
+
+-- Default ban reasons (ULX and ServerGuard)
+
+Damagelog.Ban_DefaultReason1 = "random kill"
+Damagelog.Ban_DefaultReason2 = "multiple random kills"
+Damagelog.Ban_DefaultReason3 = "random damage"
+Damagelog.Ban_DefaultReason4 = "multiple random damage"
+Damagelog.Ban_DefaultReason5 = "unfitting answer"
+Damagelog.Ban_DefaultReason6 = "unfitting answers"
+Damagelog.Ban_DefaultReason7 = "unfitting language"
+Damagelog.Ban_DefaultReason8 = "teaming"
+Damagelog.Ban_DefaultReason9 = "ghosting"
+Damagelog.Ban_DefaultReason10 = "rude"
+Damagelog.Ban_DefaultReason11 = "cheating"
+Damagelog.Ban_DefaultReason12 = "spam"
 
 -- The number of days the logs last on the database (to avoid lags when opening the menu)
 
@@ -83,3 +109,19 @@ Damagelog.UseWorkshop = true
 -- Force a language - When empty use user-defined language
 
 Damagelog.ForcedLanguage = ""
+
+-- Allow reports even with no staff online
+
+Damagelog.NoStaffReports = false
+
+-- Allow more than 2 reports per round
+
+Damagelog.MoreReportsPerRound = false
+
+-- Allow reports before playing
+
+Damagelog.ReportsBeforePlaying = false
+
+-- Private message prefix from RDM Manager
+
+Damagelog.PrivateMessagePrefix = "[RDM Manager]"

--- a/lua/damagelogs/shared/lang/deutsch.lua
+++ b/lua/damagelogs/shared/lang/deutsch.lua
@@ -105,6 +105,7 @@ DamagelogLang.deutsch = {
 	Killer = "Mörder",
 	ExplainSituation = "Erkläre die Situation. Mindestens 10 Zeichen sind erforderlich.",
 	Submit = "Absenden",
+	SubmitEvenWithNoStaff = "Absenden, obwohl kein Staffmitglied online ist",
 	NotEnoughCharacters = "Nicht genügend Zeichen zum Absenden",
 	LogsBeforeDeath = "Protokolle vor deinem Tod",
 	MessageFrom = "Nachricht von",

--- a/lua/damagelogs/shared/lang/english.lua
+++ b/lua/damagelogs/shared/lang/english.lua
@@ -105,6 +105,7 @@ DamagelogLang.english = {
 	Killer = "killer",
 	ExplainSituation = "Explain the situation. At least 10 characters are required.",
 	Submit = "Submit",
+	SubmitEvenWithNoStaff = "Submit, even if there's no staff online",
 	NotEnoughCharacters = "Not enough characters to submit",
 	LogsBeforeDeath = "Logs before your death",
 	MessageFrom = "message from",

--- a/lua/damagelogs/shared/lang/french.lua
+++ b/lua/damagelogs/shared/lang/french.lua
@@ -98,6 +98,7 @@ DamagelogLang.french = {
 	Killer = "tueur",
 	ExplainSituation = "Expliquer la situation. 10 caractères sont requis.",
 	Submit = "Envoyer",
+	SubmitEvenWithNoStaff = "Envoyer, bien qu'aucun membre du personnel ne soit en ligne",
 	NotEnoughCharacters = "Pas assez de caractères",
 	LogsBeforeDeath = "Logs avant votre mort",
 	MessageFrom = "message de",

--- a/lua/damagelogs/shared/lang/russian.lua
+++ b/lua/damagelogs/shared/lang/russian.lua
@@ -105,6 +105,7 @@ DamagelogLang.russian = {
 	Killer = "убийца",
 	ExplainSituation = "Объясните ситуацию.",
 	Submit = "Отправить",
+	SubmitEvenWithNoStaff = "Отправить, даже если весь персонал не онлайн",
 	NotEnoughCharacters = "Сообщение слишком короткое",
 	LogsBeforeDeath = "Логи до вашей смерти",
 	MessageFrom = "Сообщение от",


### PR DESCRIPTION
- added aslay-window
- added ban-option in "Take action"-menu with a ban-window (serverguard command missing - commented in code with essential variable names)
- added "send message to"-option in "Take action"-menu to let people now when they didn't report correctly for example and added option to change the prefix of those private messages in config (serverguard command missing - commented in code with essential variable names)
- fixed bug "remove ajails of" instead of "remove aslays of" and visa-versa
- added more default slay reasons in config
- added default ban reasons in config
- added option to report more than twice (switchable in config - disabled by default)
- added option to report before playing (switchable in config - disabled by default)
- added option to report with no staff online (switchable in config - disabled by default)
- changed text from "Submit" in report window to "Submit, even if there's no staff online" if there's no staff online and translated it into every language currently available