### PR TITLE
Stack overflow fix

### DIFF
--- a/lua/damagelogs/server/damageinfos.lua
+++ b/lua/damagelogs/server/damageinfos.lua
@@ -39,29 +39,12 @@ function Damagelog:shootCallback(weapon)
 	end
 end
 
-function Damagelog:DamagelogInfos()
-	for k,v in pairs(weapons.GetList()) do
-		if v.Base == "weapon_tttbase" then
-			if not v.PrimaryAttack then
-				v.PrimaryAttack = function(wep)
-					wep.BaseClass.PrimaryAttack(wep)
-					if wep.BaseClass.CanPrimaryAttack(wep) and IsValid(wep.Owner) then
-						self:shootCallback(wep)
-					end
-				end
-			else
-				local oldprimary = v.PrimaryAttack
-				v.PrimaryAttack = function(wep)
-					oldprimary(wep)
-					self:shootCallback(wep)
-				end
-			end
-		end
+hook.Add("EntityFireBullets", "BulletsCallback_DamagelogInfos", function(ent, data)
+	if not IsValid(ent) or not ent:IsPlayer() then return end
+	local wep = ent:GetActiveWeapon()
+	if IsValid(wep) and wep.Base == "weapon_tttbase" then
+		Damagelog:shootCallback(wep)
 	end
-end
-
-hook.Add("Initialize", "Initialize_DamagelogInfos", function()
-	Damagelog:DamagelogInfos()
 end)
 
 function Damagelog:SendDamageInfos(ply, t, att, victim, round)


### PR DESCRIPTION
Fixes stack overflow with certain weapons / weapon bases by hooking into EntityFireBullets() rather than modifying weapon functions. Tested on my server and is working fine.

Here was the specific error for anyone curious:
[ERROR] stack overflow
  1. GetTable - [C]:-1
   2. __index - lua/includes/extensions/weapon.lua:30
    3. PrimaryAttack - addons/ttt-logs/lua/damagelogs/server/damageinfos.lua:47
     4. PrimaryAttack - addons/ttt-logs/lua/damagelogs/server/damageinfos.lua:47
      5. PrimaryAttack - addons/ttt-logs/lua/damagelogs/server/damageinfos.lua:47