### PR TITLE
Readd support for cyrillic characters

### DIFF
--- a/lua/damagelogs/client/rdm_manager.lua
+++ b/lua/damagelogs/client/rdm_manager.lua
@@ -91,7 +91,7 @@ local function BuildReportFrame(report)
 			
 			Button.DoClick = function()
 				local text = string.Trim(TextEntry:GetValue())
-				local size = #string.gsub(text, "[%G ]+", " ")
+				local size = #text:gsub("[^%g\128-\191\208-\210 ]+", ""):gsub("%s+", " ")
 
 				if size < 10 then
 					Info:SetText(TTTLogTranslate(GetDMGLogLang, "MinCharacters"))
@@ -384,7 +384,7 @@ function Damagelog:ReportWindow(found, deathLogs, previousReports, currentReport
 	Submit:SetSize(370, 25)
 
 	Submit.Think = function(self)
-		local characters = #string.gsub(Entry:GetText(), "[%G ]+", " ")
+		local characters = #Entry:GetText():gsub("[^%g\128-\191\208-\210 ]+", ""):gsub("%s+", " ")
 		local disable = characters < 10 or not cur_selected
 
 		if disable and select(2, Type:GetSelected()) != DAMAGELOG_REPORT_CHAT then

--- a/lua/damagelogs/server/rdm_manager.lua
+++ b/lua/damagelogs/server/rdm_manager.lua
@@ -270,7 +270,7 @@ net.Receive("DL_ReportPlayer", function(_len, ply)
 		reportType = DAMAGELOG_REPORT_STANDARD
 	end
 
-	message = string_gsub(message, "[%G ]+", " ")
+	message = string_gsub(string_gsub(message, "[^%g\128-\191\208-\210 ]+", ""), "%s+", " ")
 
 	if not ply:CanUseRDMManager() then
 
@@ -546,12 +546,14 @@ end)
 
 net.Receive("DL_SendAnswer", function(_, ply)
 	local previous = net.ReadUInt(1) ~= 1
-	local text = string_gsub(net.ReadString(), "[%G ]+", " ")
+	local text = net.ReadString()
 	local index = net.ReadUInt(16)
 	local tbl = previous and Damagelog.Reports.Previous[index] or Damagelog.Reports.Current[index]
 	if not tbl then return end
 	if ply:SteamID() != tbl.attacker then return end
 	if tbl.response then return end
+
+	text = string_gsub(string_gsub(text, "[^%g\128-\191\208-\210 ]+", ""), "%s+", " ")
 	tbl.response = text
 
 	for k, v in ipairs(player_GetHumans()) do


### PR DESCRIPTION
Since one of the latest updates (the one that fixed the crash-players-with-certain-characters exploit), cyrillic characters in reports get removed.

They for some reason aren't included in `%g`. And it turned out to be not that easy to catch them in one pattern. One of the main problems with them is that they are double-byte, but after spending some time researching I came up with this solution.