### PR TITLE
Show propkills in logs + minor fix

### DIFF
--- a/lua/damagelogs/client/rdm_manager.lua
+++ b/lua/damagelogs/client/rdm_manager.lua
@@ -826,7 +826,7 @@ net.Receive("DL_SendForgive", function()
 end)
 
 net.Receive("DL_Answering_global", function(_len)
-	if not LocalPlayer():IsActive() then
+	if LocalPlayer().IsActive and not LocalPlayer():IsActive() then
 		chat.AddText(Color(255, 62, 62), net.ReadString(), color_white, " " .. TTTLogTranslate(GetDMGLogLang, "IsAnswering"))
 	end
 end)

--- a/lua/damagelogs/shared/events/suicide.lua
+++ b/lua/damagelogs/shared/events/suicide.lua
@@ -10,7 +10,7 @@ local event = {}
 event.Type = "KILL"
 
 function event:DoPlayerDeath(ply, attacker, dmginfo)
-	if ((IsValid(attacker) and attacker:IsPlayer() and attacker == ply) or (attacker == game.GetWorld())) and not (dmginfo:IsDamageType(DMG_DROWN) or (ply.IsGhost and ply:IsGhost())) then
+	if ((IsValid(attacker) and ((attacker:IsPlayer() and attacker == ply) or attacker:GetClass() == "prop_physics")) or (attacker == game.GetWorld())) and not (dmginfo:IsDamageType(DMG_DROWN) or (ply.IsGhost and ply:IsGhost())) then
 		Damagelog.SceneID = Damagelog.SceneID + 1
 		local scene = Damagelog.SceneID
 		Damagelog.SceneRounds[scene] = Damagelog.CurrentRound


### PR DESCRIPTION
`suicide.lua`: include propkills

`rdm_manager.lua`: check if `LocalPlayer():IsActive()` method exists before calling it (if net message is received when player is still connecting and entities are not fully initialized to avoid errors)