### PR TITLE
Localize 'found'

### DIFF
--- a/lua/damagelogs/server/rdm_manager.lua
+++ b/lua/damagelogs/server/rdm_manager.lua
@@ -269,6 +269,7 @@ net.Receive("DL_ReportPlayer", function(_len, ply)
 
 	if not ply:CanUseRDMManager() then
 
+		local found
 		for k, v in ipairs(player_GetHumans()) do
 			if v:CanUseRDMManager() then
 				found = true


### PR DESCRIPTION
Minor change: localize the `found` variable in `rdm_manager.lua`.

---
Also, a question: I implemented integration with Discord Webhooks on my server: when a report is created and no admins are online, a message is created in Discord.

Would it be useful as a standart feature? Should I create a PR implementing it or is it too specific of a thing to add?