### PR TITLE
Make translation function return false instead of 'Missing:' for weapon names

### DIFF
--- a/lua/damagelogs/client/weapon_names.lua
+++ b/lua/damagelogs/client/weapon_names.lua
@@ -1,7 +1,7 @@
 Damagelog.NamesTable = Damagelog.NamesTable or {}
 
 function Damagelog:GetWeaponName(class)
-    return self.NamesTable[class] or TTTLogTranslate(GetDMGLogLang, class) or class
+    return self.NamesTable[class] or TTTLogTranslate(GetDMGLogLang, class, true) or class
 end
 
 local function UpdateWeaponNames()

--- a/lua/damagelogs/shared/lang.lua
+++ b/lua/damagelogs/shared/lang.lua
@@ -8,7 +8,7 @@ for k,v in pairs(file.Find("damagelogs/shared/lang/*.lua", "LUA")) do
 	include(f)
 end
 
-function TTTLogTranslate(GetDMGLogLang, phrase)
+function TTTLogTranslate(GetDMGLogLang, phrase, nomissing)
 	local f = GetDMGLogLang
 	if Damagelog.ForcedLanguage == "" then
 		if !DamagelogLang[f] then
@@ -17,5 +17,5 @@ function TTTLogTranslate(GetDMGLogLang, phrase)
 	else
 		f = Damagelog.ForcedLanguage
 	end
-	return DamagelogLang[f][phrase] or "Missing: "..tostring(phrase)
+	return DamagelogLang[f][phrase] or not nomissing and "Missing: "..tostring(phrase)
 end


### PR DESCRIPTION
Right now it displays 'Missing: (playername)' in DNA lines or 'Missing: false' in damage lines for some weapons.