### PR TITLE
Fix #397

### DIFF
--- a/lua/damagelogs/shared/lang.lua
+++ b/lua/damagelogs/shared/lang.lua
@@ -21,5 +21,5 @@ function TTTLogTranslate(GetDMGLogLang, phrase, nomissing)
         f = Damagelog.ForcedLanguage
     end
 
-    return DamagelogLang[f][phrase] or LANG.TryTranslation(phrase) or not nomissing and "Missing: " .. tostring(phrase)
+    return DamagelogLang[f][phrase] or DamagelogLang["english"][phrase] or LANG.TryTranslation(phrase) or not nomissing and "Missing: " .. tostring(phrase)
 end


### PR DESCRIPTION
This makes the translation function check the english translation first before using TTT's builtin translation system. The latter sometimes breaks, causing #397.